### PR TITLE
make the function calling small language models friendly

### DIFF
--- a/internal/services/ai.go
+++ b/internal/services/ai.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
-	"github.com/openai/openai-go/packages/param"
 )
 
 // AIService handles AI interactions with OpenAI
@@ -140,10 +139,10 @@ func (ai *AIService) ProcessChatMessage(ctx context.Context, sessionID string, s
 	for currentIteration < maxIterations {
 		// Create the chat completion request
 		completion, err := ai.client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
-			Model:       model,
-			Messages:    messages,
+			Model:             model,
+			Messages:          messages,
 			ParallelToolCalls: openai.Bool(true),
-			Tools:       tools,
+			Tools:             tools,
 			Temperature:       openai.Opt(0.0),
 		})
 

--- a/internal/services/ai.go
+++ b/internal/services/ai.go
@@ -242,7 +242,7 @@ func (ai *AIService) getToolDefinitions() []openai.ChatCompletionToolParam {
 			Type: "function",
 			Function: openai.FunctionDefinitionParam{
 				Name:        "add_to_cart",
-				Description: openai.String("Add a product to the shopping cart"),
+				Description: openai.String("Add a quantity of a product to the shopping cart"),
 				Parameters: openai.FunctionParameters{
 					"type": "object",
 					"properties": map[string]interface{}{
@@ -255,7 +255,7 @@ func (ai *AIService) getToolDefinitions() []openai.ChatCompletionToolParam {
 							"description": "Quantity to add (default: 1)",
 						},
 					},
-					"required": []string{"product_name"},
+					"required": []string{"product_name", "quantity"},
 				},
 			},
 		},

--- a/internal/services/ai.go
+++ b/internal/services/ai.go
@@ -109,7 +109,7 @@ func (ai *AIService) ProcessChatMessage(ctx context.Context, sessionID string, s
 	var responseMessage string
 
 	// Maximum number of tool call iterations
-	maxIterations := 5
+	maxIterations := 1
 	currentIteration := 0
 
 	// Use provided settings or defaults
@@ -142,8 +142,9 @@ func (ai *AIService) ProcessChatMessage(ctx context.Context, sessionID string, s
 		completion, err := ai.client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
 			Model:       model,
 			Messages:    messages,
+			ParallelToolCalls: openai.Bool(true),
 			Tools:       tools,
-			Temperature: param.Opt[float64]{Value: 0.00000000000001},
+			Temperature:       openai.Opt(0.0),
 		})
 
 		if err != nil {
@@ -189,7 +190,7 @@ func (ai *AIService) ProcessChatMessage(ctx context.Context, sessionID string, s
 
 	// If we hit the maximum iterations, add a warning message
 	if currentIteration >= maxIterations {
-		responseMessage = "I've reached the maximum number of operations I can perform. Let me know if you need anything else!"
+		responseMessage = "Let me know if you need anything else!"
 	}
 
 	// Get the final cart summary after all tool executions

--- a/internal/services/ai.go
+++ b/internal/services/ai.go
@@ -206,27 +206,9 @@ func (ai *AIService) ProcessChatMessage(ctx context.Context, sessionID string, s
 
 // getSystemPrompt returns the system prompt for the AI
 func (ai *AIService) getSystemPrompt() string {
-	return `You are a helpful shopping assistant for chat2cart, an AI-powered shopping platform. Your role is to help users discover products, manage their shopping cart, and complete purchases through natural conversation.
-
-Key capabilities:
-- Search for products by name, description, or category
-- Add products to the shopping cart
-- Remove products from the cart
-- Update quantities in the cart
-- Show cart contents and totals
-- Process checkout
-
-Guidelines:
-- Be friendly, helpful, and conversational
-- Ask clarifying questions when needed (e.g., quantity, specific product details)
-- Provide product recommendations when appropriate
-- Always confirm actions like adding/removing items
-- Help users understand their cart contents and totals
-- Guide users through the checkout process
-
-Available product categories: electronics, clothing, books, home, sports
-
-When users ask about products, use the search_products tool to find relevant items. When they want to add items to their cart, use the appropriate cart management tools.`
+	return `You are a helpful shopping assistant for chat2cart, an AI-powered shopping platform. 
+	Your role is to help users discover products, manage their shopping cart, and complete purchases through natural conversation.
+	`
 }
 
 // getToolDefinitions returns the tool definitions for OpenAI function calling


### PR DESCRIPTION
- I simplified the system prompt: the instructions are in the tool descriptions, and it should be enough for the model
- I updated the description of the `add_to_cart` tool and made the `quantity` mandatory
- I reduced the number of iterations to 1 and used `ParallelToolCalls: openai.Bool(true)` in the chat completion params

With `ParallelToolCalls: openai.Bool(true)` you can avoid looping over the messages to execute the tools one by one.